### PR TITLE
Enabled reconnecting with new socket.

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -13,6 +13,7 @@
     return name.replace(/^\/|\/$/g, '');
   };
 
+  // The socket will be set up here to respond to changes.
   var connection = new Map({});
 
   var SocketModel = Model.extend({

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -14,7 +14,9 @@
     };
 
     // The socket will be set up here to respond to changes.
-    var connection = new Map({});
+    var connection = new Map({
+      ready:can.Deferred()
+    });
 
     // A place to keep track of all connected resources.
     var resources = [];

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -16,6 +16,13 @@
   // The socket will be set up here to respond to changes.
   var connection = new Map({});
 
+  // A place to keep track of all connected resources.
+  var resources = [];
+  // When a new socket is set, each resource needs to have new handlers set up.
+  // `resourceCount` is used to make sure all new listeners are in place before any
+  // queries are sent off.
+  var resourceCount = 0;
+
   var SocketModel = Model.extend({
     // Here we store locks that prevent dispatching
     // created, updated and removed events multiple times
@@ -28,6 +35,9 @@
       if(this.resource) {
         var self = this;
         var resource = stripSlashes(this.resource);
+
+        // Add the resource to the `resources` list.
+        resources.push(resource);
 
         // Creates a resource event handler function for a given event
         var makeHandler = function(ev) {
@@ -63,6 +73,12 @@
             socket.on(resource + ' created', makeHandler('create'));
             socket.on(resource + ' updated', makeHandler('update'));
             socket.on(resource + ' removed', makeHandler('remove'));
+
+            resourceCount++;
+            // When these are equal, all handlers have been set up. Resolve.
+            if (resources.length === resourceCount) {
+              connection.attr('ready').resolve(socket);
+            };
 
           // Tear down old listeners when connection.socket is removed.
           } else {
@@ -119,7 +135,9 @@
         deferred.resolve(data);
       });
 
-      connection.attr('socket').emit.apply(socket, args);
+      connection.attr('ready').done(function(socket){
+        socket.emit.apply(socket, args);
+      });
 
       return deferred;
     }
@@ -137,14 +155,24 @@
     connect: function(socket) {
       // If there's an existing socket...
       if (connection.attr('socket')) {
-        // and disconnect the socket.
+        // ... disconnect it.
         connection.attr('socket').disconnect();
-
-        // ... trigger removal of old listeners/handlers,
+        // ... trigger removal of old listeners,
         connection.removeAttr('socket');
-      };
+        // Reset the resource resourceCount.
+        resourceCount = 0;
+      }
+
+      connection.attr('ready', new can.Deferred());
+
       // Put the new socket in place.
       connection.attr('socket', socket);
+    },
+
+    disconnect:function(){
+      if (connection.attr('socket')) {
+        connection.attr('socket').disconnect();
+      }
     }
   };
 

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -159,7 +159,7 @@
           connection.attr('socket').disconnect();
           // ... trigger removal of old listeners,
           connection.removeAttr('socket');
-          // Reset the resource resourceCount.
+          // Reset the resourceCount.
           resourceCount = 0;
         }
 

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -1,180 +1,180 @@
 'use strict';
 
-(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-      define(['can/util/library', 'can/model', 'can/map'], factory);
-  } else if (typeof exports === 'object') {
-      module.exports = factory(require('can/util/library'), require('can/model'), require('can/map'));
-  } else if(typeof window !== 'undefined' && root && root.can) {
-      factory(root.can, root.can.Model, root.can.Map);
-  }
+  (function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['can/util/library', 'can/model', 'can/map'], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory(require('can/util/library'), require('can/model'), require('can/map'));
+    } else if(typeof window !== 'undefined' && root && root.can) {
+        factory(root.can, root.can.Model, root.can.Map);
+    }
 }(this, function (can, Model, Map) {
-  var stripSlashes = function (name) {
-    return name.replace(/^\/|\/$/g, '');
-  };
+    var stripSlashes = function (name) {
+      return name.replace(/^\/|\/$/g, '');
+    };
 
-  // The socket will be set up here to respond to changes.
-  var connection = new Map({});
+    // The socket will be set up here to respond to changes.
+    var connection = new Map({});
 
-  // A place to keep track of all connected resources.
-  var resources = [];
-  // When a new socket is set, each resource needs to have new handlers set up.
-  // `resourceCount` is used to make sure all new listeners are in place before any
-  // queries are sent off.
-  var resourceCount = 0;
+    // A place to keep track of all connected resources.
+    var resources = [];
+    // When a new socket is set, each resource needs to have new handlers set up.
+    // `resourceCount` is used to make sure all new listeners are in place before any
+    // queries are sent off.
+    var resourceCount = 0;
 
-  var SocketModel = Model.extend({
-    // Here we store locks that prevent dispatching
-    // created, updated and removed events multiple times
-    _locks: {},
-    connect: can.Deferred(),
+    var SocketModel = Model.extend({
+      // Here we store locks that prevent dispatching
+      // created, updated and removed events multiple times
+      _locks: {},
+      connect: can.Deferred(),
 
-    setup: function () {
-      Model.setup.apply(this, arguments);
+      setup: function () {
+        Model.setup.apply(this, arguments);
 
-      if(this.resource) {
-        var self = this;
-        var resource = stripSlashes(this.resource);
+        if(this.resource) {
+          var self = this;
+          var resource = stripSlashes(this.resource);
 
-        // Add the resource to the `resources` list.
-        resources.push(resource);
+          // Add the resource to the `resources` list.
+          resources.push(resource);
 
-        // Creates a resource event handler function for a given event
-        var makeHandler = function(ev) {
-          return function(data) {
-            var id = data[self.id];
-            // Check if this id is locked and contains e.g. a 'created'
-            // Which means that we are getting the duplicate event from the
-            // Socket remove the lock but don't dispatch the event
-            if(self._locks[id] === ev + 'd') {
-              delete self._locks[id];
-              // If we are currently updating or removing we ignore all
-              // other resource events for this model instance
-            } else if(self._locks[id] !== ev) {
-              // Mapping from CanJS to Feathers event name
-              var modelEvent = ev === 'remove' ? 'destroyed' : ev + 'd';
+          // Creates a resource event handler function for a given event
+          var makeHandler = function(ev) {
+            return function(data) {
+              var id = data[self.id];
+              // Check if this id is locked and contains e.g. a 'created'
+              // Which means that we are getting the duplicate event from the
+              // Socket remove the lock but don't dispatch the event
+              if(self._locks[id] === ev + 'd') {
+                delete self._locks[id];
+                // If we are currently updating or removing we ignore all
+                // other resource events for this model instance
+              } else if(self._locks[id] !== ev) {
+                // Mapping from CanJS to Feathers event name
+                var modelEvent = ev === 'remove' ? 'destroyed' : ev + 'd';
 
-              // Don't trigger the create event on the model if it's
-              // already in the model store, but still trigger other events.
-              if (!(ev === 'create' && self.store[id])) {
-                // Trigger the event from the resource as a model event
-                var model = self.model(data);
-                if(model[modelEvent]) {
-                  model[modelEvent]();
+                // Don't trigger the create event on the model if it's
+                // already in the model store, but still trigger other events.
+                if (!(ev === 'create' && self.store[id])) {
+                  // Trigger the event from the resource as a model event
+                  var model = self.model(data);
+                  if(model[modelEvent]) {
+                    model[modelEvent]();
+                  }
                 }
               }
-            }
-          };
-        };
-
-        connection.bind('socket', function(ev, socket){
-          // Set up listeners when a connection.socket is set.
-          if (socket) {
-            socket.on(resource + ' created', makeHandler('create'));
-            socket.on(resource + ' updated', makeHandler('update'));
-            socket.on(resource + ' removed', makeHandler('remove'));
-
-            resourceCount++;
-            // When these are equal, all handlers have been set up. Resolve.
-            if (resources.length === resourceCount) {
-              connection.attr('ready').resolve(socket);
             };
+          };
 
-          // Tear down old listeners when connection.socket is removed.
-          } else {
-            connection.attr('socket').removeAllListeners(resource + ' created')
-            connection.attr('socket').removeAllListeners(resource + ' updated')
-            connection.attr('socket').removeAllListeners(resource + ' removed')
+          connection.bind('socket', function(ev, socket){
+            // Set up listeners when a connection.socket is set.
+            if (socket) {
+              socket.on(resource + ' created', makeHandler('create'));
+              socket.on(resource + ' updated', makeHandler('update'));
+              socket.on(resource + ' removed', makeHandler('remove'));
+
+              resourceCount++;
+              // When these are equal, all handlers have been set up. Resolve.
+              if (resources.length === resourceCount) {
+                connection.attr('ready').resolve(socket);
+              };
+
+            // Tear down old listeners when connection.socket is removed.
+            } else {
+              connection.attr('socket').removeAllListeners(resource + ' created')
+              connection.attr('socket').removeAllListeners(resource + ' updated')
+              connection.attr('socket').removeAllListeners(resource + ' removed')
+            }
+          });
+
+          this.findAll = function (params) {
+            return this.send('find', params || {});
+          },
+
+          this.findOne = function (params) {
+            return this.send('get', params.id, params);
+          },
+
+          this.create = function (attrs, params) {
+            return this.send('create', attrs, params || {});
+          },
+
+          this.update = function (id, attrs, params) {
+            var ev = this._locks[id] = 'update';
+            return this.send(ev, id, attrs, params || {});
+          },
+
+          this.destroy = function (id, attrs, params) {
+            var ev = this._locks[id] = 'remove';
+            return this.send(ev, id, params || {});
           }
+        }
+      },
+
+      send: function () {
+        var deferred = can.Deferred();
+        var args = can.makeArray(arguments);
+        var name = args[0];
+        var self = this;
+
+        // Turn something like 'find' into todos::find
+        args[0] = stripSlashes(this.resource) + '::' + name;
+
+        // Add the success callback which just resolves or fails the Deferred
+        args.push(function (error, data) {
+          if (error) {
+            return deferred.reject(error);
+          }
+
+          // Set the lock so that we don't dispatch duplicate events
+          if(name === 'create' || name === 'remove' || name === 'update') {
+            self._locks[data[self.id]] = name + 'd';
+          }
+
+          deferred.resolve(data);
         });
 
-        this.findAll = function (params) {
-          return this.send('find', params || {});
-        },
+        connection.attr('ready').done(function(socket){
+          socket.emit.apply(socket, args);
+        });
 
-        this.findOne = function (params) {
-          return this.send('get', params.id, params);
-        },
-
-        this.create = function (attrs, params) {
-          return this.send('create', attrs, params || {});
-        },
-
-        this.update = function (id, attrs, params) {
-          var ev = this._locks[id] = 'update';
-          return this.send(ev, id, attrs, params || {});
-        },
-
-        this.destroy = function (id, attrs, params) {
-          var ev = this._locks[id] = 'remove';
-          return this.send(ev, id, params || {});
-        }
+        return deferred;
       }
-    },
+    }, {});
 
-    send: function () {
-      var deferred = can.Deferred();
-      var args = can.makeArray(arguments);
-      var name = args[0];
-      var self = this;
+    can.Feathers = {
+      Model: SocketModel,
 
-      // Turn something like 'find' into todos::find
-      args[0] = stripSlashes(this.resource) + '::' + name;
+      model: function (resource) {
+        return SocketModel.extend({
+          resource: resource
+        }, {});
+      },
 
-      // Add the success callback which just resolves or fails the Deferred
-      args.push(function (error, data) {
-        if (error) {
-          return deferred.reject(error);
+      connect: function(socket) {
+        // If there's an existing socket...
+        if (connection.attr('socket')) {
+          // ... disconnect it.
+          connection.attr('socket').disconnect();
+          // ... trigger removal of old listeners,
+          connection.removeAttr('socket');
+          // Reset the resource resourceCount.
+          resourceCount = 0;
         }
 
-        // Set the lock so that we don't dispatch duplicate events
-        if(name === 'create' || name === 'remove' || name === 'update') {
-          self._locks[data[self.id]] = name + 'd';
+        connection.attr('ready', new can.Deferred());
+
+        // Put the new socket in place.
+        connection.attr('socket', socket);
+      },
+
+      disconnect:function(){
+        if (connection.attr('socket')) {
+          connection.attr('socket').disconnect();
         }
-
-        deferred.resolve(data);
-      });
-
-      connection.attr('ready').done(function(socket){
-        socket.emit.apply(socket, args);
-      });
-
-      return deferred;
-    }
-  }, {});
-
-  can.Feathers = {
-    Model: SocketModel,
-
-    model: function (resource) {
-      return SocketModel.extend({
-        resource: resource
-      }, {});
-    },
-
-    connect: function(socket) {
-      // If there's an existing socket...
-      if (connection.attr('socket')) {
-        // ... disconnect it.
-        connection.attr('socket').disconnect();
-        // ... trigger removal of old listeners,
-        connection.removeAttr('socket');
-        // Reset the resource resourceCount.
-        resourceCount = 0;
       }
+    };
 
-      connection.attr('ready', new can.Deferred());
-
-      // Put the new socket in place.
-      connection.attr('socket', socket);
-    },
-
-    disconnect:function(){
-      if (connection.attr('socket')) {
-        connection.attr('socket').disconnect();
-      }
-    }
-  };
-
-  return can.Feathers;
+    return can.Feathers;
 }));

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -1,151 +1,151 @@
 'use strict';
 
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define(['can/util/library', 'can/model', 'can/map'], factory);
-    } else if (typeof exports === 'object') {
-        module.exports = factory(require('can/util/library'), require('can/model'), require('can/map'));
-    } else if(typeof window !== 'undefined' && root && root.can) {
-        factory(root.can, root.can.Model, root.can.Map);
-    }
+  if (typeof define === 'function' && define.amd) {
+      define(['can/util/library', 'can/model', 'can/map'], factory);
+  } else if (typeof exports === 'object') {
+      module.exports = factory(require('can/util/library'), require('can/model'), require('can/map'));
+  } else if(typeof window !== 'undefined' && root && root.can) {
+      factory(root.can, root.can.Model, root.can.Map);
+  }
 }(this, function (can, Model, Map) {
-    var stripSlashes = function (name) {
-      return name.replace(/^\/|\/$/g, '');
-    };
+  var stripSlashes = function (name) {
+    return name.replace(/^\/|\/$/g, '');
+  };
 
-    var connection = new Map({});
+  var connection = new Map({});
 
-    var SocketModel = Model.extend({
-      // Here we store locks that prevent dispatching
-      // created, updated and removed events multiple times
-      _locks: {},
-      connect: can.Deferred(),
+  var SocketModel = Model.extend({
+    // Here we store locks that prevent dispatching
+    // created, updated and removed events multiple times
+    _locks: {},
+    connect: can.Deferred(),
 
-      setup: function () {
-        Model.setup.apply(this, arguments);
+    setup: function () {
+      Model.setup.apply(this, arguments);
 
-        if(this.resource) {
-          var self = this;
-          var resource = stripSlashes(this.resource);
+      if(this.resource) {
+        var self = this;
+        var resource = stripSlashes(this.resource);
 
-          // Creates a resource event handler function for a given event
-          var makeHandler = function(ev) {
-            return function(data) {
-              var id = data[self.id];
-              // Check if this id is locked and contains e.g. a 'created'
-              // Which means that we are getting the duplicate event from the
-              // Socket remove the lock but don't dispatch the event
-              if(self._locks[id] === ev + 'd') {
-                delete self._locks[id];
-                // If we are currently updating or removing we ignore all
-                // other resource events for this model instance
-              } else if(self._locks[id] !== ev) {
-                // Mapping from CanJS to Feathers event name
-                var modelEvent = ev === 'remove' ? 'destroyed' : ev + 'd';
+        // Creates a resource event handler function for a given event
+        var makeHandler = function(ev) {
+          return function(data) {
+            var id = data[self.id];
+            // Check if this id is locked and contains e.g. a 'created'
+            // Which means that we are getting the duplicate event from the
+            // Socket remove the lock but don't dispatch the event
+            if(self._locks[id] === ev + 'd') {
+              delete self._locks[id];
+              // If we are currently updating or removing we ignore all
+              // other resource events for this model instance
+            } else if(self._locks[id] !== ev) {
+              // Mapping from CanJS to Feathers event name
+              var modelEvent = ev === 'remove' ? 'destroyed' : ev + 'd';
 
-                // Don't trigger the create event on the model if it's
-                // already in the model store, but still trigger other events.
-                if (!(ev === 'create' && self.store[id])) {
-                  // Trigger the event from the resource as a model event
-                  var model = self.model(data);
-                  if(model[modelEvent]) {
-                    model[modelEvent]();
-                  }
+              // Don't trigger the create event on the model if it's
+              // already in the model store, but still trigger other events.
+              if (!(ev === 'create' && self.store[id])) {
+                // Trigger the event from the resource as a model event
+                var model = self.model(data);
+                if(model[modelEvent]) {
+                  model[modelEvent]();
                 }
               }
-            };
-          };
-
-          connection.bind('socket', function(ev, socket){
-            // Set up listeners when a connection.socket is set.
-            if (socket) {
-              socket.on(resource + ' created', makeHandler('create'));
-              socket.on(resource + ' updated', makeHandler('update'));
-              socket.on(resource + ' removed', makeHandler('remove'));
-
-            // Tear down old listeners when connection.socket is removed.
-            } else {
-              connection.attr('socket').removeAllListeners(resource + ' created')
-              connection.attr('socket').removeAllListeners(resource + ' updated')
-              connection.attr('socket').removeAllListeners(resource + ' removed')
             }
-          });
+          };
+        };
 
-          this.findAll = function (params) {
-            return this.send('find', params || {});
-          },
+        connection.bind('socket', function(ev, socket){
+          // Set up listeners when a connection.socket is set.
+          if (socket) {
+            socket.on(resource + ' created', makeHandler('create'));
+            socket.on(resource + ' updated', makeHandler('update'));
+            socket.on(resource + ' removed', makeHandler('remove'));
 
-          this.findOne = function (params) {
-            return this.send('get', params.id, params);
-          },
-
-          this.create = function (attrs, params) {
-            return this.send('create', attrs, params || {});
-          },
-
-          this.update = function (id, attrs, params) {
-            var ev = this._locks[id] = 'update';
-            return this.send(ev, id, attrs, params || {});
-          },
-
-          this.destroy = function (id, attrs, params) {
-            var ev = this._locks[id] = 'remove';
-            return this.send(ev, id, params || {});
+          // Tear down old listeners when connection.socket is removed.
+          } else {
+            connection.attr('socket').removeAllListeners(resource + ' created')
+            connection.attr('socket').removeAllListeners(resource + ' updated')
+            connection.attr('socket').removeAllListeners(resource + ' removed')
           }
-        }
-      },
-
-      send: function () {
-        var deferred = can.Deferred();
-        var args = can.makeArray(arguments);
-        var name = args[0];
-        var self = this;
-
-        // Turn something like 'find' into todos::find
-        args[0] = stripSlashes(this.resource) + '::' + name;
-
-        // Add the success callback which just resolves or fails the Deferred
-        args.push(function (error, data) {
-          if (error) {
-            return deferred.reject(error);
-          }
-
-          // Set the lock so that we don't dispatch duplicate events
-          if(name === 'create' || name === 'remove' || name === 'update') {
-            self._locks[data[self.id]] = name + 'd';
-          }
-
-          deferred.resolve(data);
         });
 
-        connection.attr('socket').emit.apply(socket, args);
+        this.findAll = function (params) {
+          return this.send('find', params || {});
+        },
 
-        return deferred;
+        this.findOne = function (params) {
+          return this.send('get', params.id, params);
+        },
+
+        this.create = function (attrs, params) {
+          return this.send('create', attrs, params || {});
+        },
+
+        this.update = function (id, attrs, params) {
+          var ev = this._locks[id] = 'update';
+          return this.send(ev, id, attrs, params || {});
+        },
+
+        this.destroy = function (id, attrs, params) {
+          var ev = this._locks[id] = 'remove';
+          return this.send(ev, id, params || {});
+        }
       }
-    }, {});
+    },
 
-    can.Feathers = {
-      Model: SocketModel,
+    send: function () {
+      var deferred = can.Deferred();
+      var args = can.makeArray(arguments);
+      var name = args[0];
+      var self = this;
 
-      model: function (resource) {
-        return SocketModel.extend({
-          resource: resource
-        }, {});
-      },
+      // Turn something like 'find' into todos::find
+      args[0] = stripSlashes(this.resource) + '::' + name;
 
-      connect: function(socket) {
-        // If there's an existing socket...
-        if (connection.attr('socket')) {
-          // and disconnect the socket.
-          connection.attr('socket').disconnect();
+      // Add the success callback which just resolves or fails the Deferred
+      args.push(function (error, data) {
+        if (error) {
+          return deferred.reject(error);
+        }
 
-          // ... trigger removal of old listeners/handlers,
-          connection.removeAttr('socket');
-        };
-        // Put the new socket in place.
-        connection.attr('socket', socket);
-      }
-    };
+        // Set the lock so that we don't dispatch duplicate events
+        if(name === 'create' || name === 'remove' || name === 'update') {
+          self._locks[data[self.id]] = name + 'd';
+        }
 
-    return can.Feathers;
+        deferred.resolve(data);
+      });
+
+      connection.attr('socket').emit.apply(socket, args);
+
+      return deferred;
+    }
+  }, {});
+
+  can.Feathers = {
+    Model: SocketModel,
+
+    model: function (resource) {
+      return SocketModel.extend({
+        resource: resource
+      }, {});
+    },
+
+    connect: function(socket) {
+      // If there's an existing socket...
+      if (connection.attr('socket')) {
+        // and disconnect the socket.
+        connection.attr('socket').disconnect();
+
+        // ... trigger removal of old listeners/handlers,
+        connection.removeAttr('socket');
+      };
+      // Put the new socket in place.
+      connection.attr('socket', socket);
+    }
+  };
+
+  return can.Feathers;
 }));

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -71,7 +71,6 @@
             }
           });
 
-
           this.findAll = function (params) {
             return this.send('find', params || {});
           },
@@ -135,7 +134,15 @@
       },
 
       connect: function(socket) {
-        connection.removeAttr('socket');
+        // If there's an existing socket...
+        if (connection.attr('socket')) {
+          // and disconnect the socket.
+          connection.attr('socket').disconnect();
+
+          // ... trigger removal of old listeners/handlers,
+          connection.removeAttr('socket');
+        };
+        // Put the new socket in place.
         connection.attr('socket', socket);
       }
     };

--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -2,19 +2,21 @@
 
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['can/util/library', 'can/model'], factory);
+        define(['can/util/library', 'can/model', 'can/map'], factory);
     } else if (typeof exports === 'object') {
-        module.exports = factory(require('can/util/library'), require('can/model'));
+        module.exports = factory(require('can/util/library'), require('can/model'), require('can/map'));
     } else if(typeof window !== 'undefined' && root && root.can) {
-        factory(root.can, root.can.Model);
+        factory(root.can, root.can.Model, root.can.Map);
     }
-}(this, function (can, Model) {
+}(this, function (can, Model, Map) {
     var stripSlashes = function (name) {
       return name.replace(/^\/|\/$/g, '');
     };
 
+    var connection = new Map({});
+
     var SocketModel = Model.extend({
-      // Here we store locks that prevent disaptching
+      // Here we store locks that prevent dispatching
       // created, updated and removed events multiple times
       _locks: {},
       connect: can.Deferred(),
@@ -54,11 +56,21 @@
             };
           };
 
-          this.connect.done(function(socket) {
-            socket.on(resource + ' created', makeHandler('create'));
-            socket.on(resource + ' updated', makeHandler('update'));
-            socket.on(resource + ' removed', makeHandler('remove'));
+          connection.bind('socket', function(ev, socket){
+            // Set up listeners when a connection.socket is set.
+            if (socket) {
+              socket.on(resource + ' created', makeHandler('create'));
+              socket.on(resource + ' updated', makeHandler('update'));
+              socket.on(resource + ' removed', makeHandler('remove'));
+
+            // Tear down old listeners when connection.socket is removed.
+            } else {
+              connection.attr('socket').removeAllListeners(resource + ' created')
+              connection.attr('socket').removeAllListeners(resource + ' updated')
+              connection.attr('socket').removeAllListeners(resource + ' removed')
+            }
           });
+
 
           this.findAll = function (params) {
             return this.send('find', params || {});
@@ -107,9 +119,7 @@
           deferred.resolve(data);
         });
 
-        this.connect.done(function(socket) {
-          socket.emit.apply(socket, args);
-        });
+        connection.attr('socket').emit.apply(socket, args);
 
         return deferred;
       }
@@ -125,15 +135,8 @@
       },
 
       connect: function(socket) {
-        var dfd = SocketModel.connect;
-
-        if(socket && dfd.state() !== 'resolved') {
-          dfd.resolve(socket);
-        } else if(socket) {
-          throw new Error('There already seems to be a socket connection.');
-        }
-
-        return dfd;
+        connection.removeAttr('socket');
+        connection.attr('socket', socket);
       }
     };
 


### PR DESCRIPTION
This PR makes `canjs-feathers` compatible with apps that use authentication, especially if realtime communication is needed both BEFORE and AFTER authentication.  Now it is possible, after connecting unauthenticated, to switch to an authenticated socket connection and do something like the example below.  Assume that a todos model as been set up, already.

```js
// Connect without authentication...
var socket = io('', {transports: ['websocket'] });
can.Feathers.connect(socket);

todos.findAll({}) // gets public todos



// Then later, with authentication...
socket = io('', {
	query: 'token=' + localStorage.getItem('featherstoken'),
	transports: ['websocket'],
	forceNew:true, // this is required
});
can.Feathers.connect(socket);

todos.findAll({}) // gets public todos and the user's private todos.
```

I've set up the imports to bring in can.Map.  The connection Map stores the `socket` and also a `ready` deferred to use when switching sockets.  Upon making a second connection with `can.Feathers.connect(socket)`, the previous socket is disconnected then removed from the connection Map, which triggers removal of all of the old handlers.  When the new socket is set up on the connection Map, queries are deferred until all of the handlers have been set up on each resource.

I also added `can.Feathers.disconnect()`;

I tried to test this using the instructions here to work with an existing grunt project: http://gruntjs.com/getting-started, but grunt kept telling me that a gruntfile wasn't found.  (Maybe I should be ashamed to admit that I've not used grunt, only gulp. :)  So, although I haven't run the tests in the test folder, I haven't run into any issues.