### PR TITLE
Order of start/Model creation shouldn't matter.

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -12,14 +12,15 @@
 
   var connection = new Map({
     // The socket is set up here to respond to changes.
-    socket:{}
+    socket:{},
+    def:new can.Deferred()
   });
 
   var SocketModel = Model.extend({
     // Here we store locks that prevent dispatching
     // created, updated and removed events multiple times
     _locks: {},
-    ready: new can.Deferred(),
+    ready: can.Deferred(),
 
     setup: function () {
       var self = this;
@@ -30,7 +31,10 @@
         return false;
       }
 
-      this.makeClient();
+      // Make sure there's a socket in place before making the internal client.
+      connection.def.then(function(){
+        self.makeClient();
+      });
 
       this.create = function (attrs, params) {
         return this.send('create', null, attrs, params || {});
@@ -49,7 +53,9 @@
       // If the socket changes, update the internal Feathers client.
       connection.bind('socket', function(ev, socket){
         if (socket) {
-          self.ready = new can.Deferred();
+          if (self.ready.state() !== 'pending') {
+            self.ready = new can.Deferred();
+          }
           self.makeClient();
         }
       });
@@ -63,7 +69,7 @@
         name = args.shift();
 
       // Name doesn't use id.
-      if (name == 'create') {
+      if (name === 'create') {
         args.splice(0, 1);
       }
 
@@ -145,8 +151,8 @@
       this.client = feathersClient(this.resource, socket);
 
       // Setup new event handlers.
-      for (var i = 0; i < events.length; i++) {
-        this.client.on(events[i] + 'd', this.makeHandler(events[i]));
+      for (var n = 0; n < events.length; n++) {
+        this.client.on(events[n] + 'd', this.makeHandler(events[n]));
       }
 
       this.ready.resolve();
@@ -226,7 +232,8 @@
         self.socketID = socket.id;
 
         def.resolve(socket);
-      };
+        connection.def.resolve();
+      }
 
       // If the socket is connected...
       if(socket.connected){

--- a/test/test.js
+++ b/test/test.js
@@ -91,65 +91,68 @@
       };
       var newSocket = io.connect('', params);
 
-      newSocket.on('connect', function(){
+      can.Feathers.connect(newSocket).then(function(sock) {
 
-        can.Feathers.connect(newSocket).then(function(sock) {
+        var Task = can.Feathers.model('/todos/');
 
-          var laundry = new Todo({ description: 'Do some laundry!' });
-          var expectedLatest = {
-            id: 0,
-            description: 'Really do laundry!',
-            done: false
-          };
+        var laundry = new Todo({ description: 'Do some laundry!' });
+        var expectedLatest = {
+          id: 0,
+          description: 'Really do laundry!',
+          done: false
+        };
 
-          // First we need to clear all our test todos
-          can.ajax({
-            url: '/todos/clear',
-            dataType: 'json'
-          }).then(function () {
-            // ::create
-            laundry.save().then(function (todo) {
-              assert.deepEqual(todo.attr(), {
-                id: 0,
-                description: 'Do some laundry!',
-                done: false
-              });
-
-              todo.attr('description', 'Really do laundry!');
-
-              // ::update
-              return todo.save();
-            })
-            .then(function () {
-              // ::find
-              return Todo.findAll();
-            })
-            .then(function (todos) {
-              assert.equal(todos.length, 1, 'Got one todo');
-              assert.deepEqual(todos[0].attr(), expectedLatest,
-                'findAll returned with updated Todo');
-              // ::get
-              return Todo.findOne({ id: todos[0].id });
-            })
-            .then(function (todo) {
-              assert.deepEqual(todo.attr(), expectedLatest, 'findOne returned');
-              // ::remove
-              return todo.destroy();
-            })
-            .then(function () {
-              return Todo.findAll();
-            })
-            .then(function (todos) {
-              assert.equal(todos.length, 0, 'Deleted todo');
-              assert.equal(sock.id, newSocket.id, 'New socket ids match.');
-              assert.notEqual(socket.id, sock.id, 'Not using old socket.');
-
-              assert.equal(todos.length, 0, 'Deleted todo');
-              done();
+        // First we need to clear all our test todos
+        can.ajax({
+          url: '/todos/clear',
+          dataType: 'json'
+        }).then(function () {
+          // ::create
+          laundry.save().then(function (todo) {
+            assert.deepEqual(todo.attr(), {
+              id: 0,
+              description: 'Do some laundry!',
+              done: false
             });
+
+            todo.attr('description', 'Really do laundry!');
+
+            // ::update
+            return todo.save();
+          })
+          .then(function () {
+            // ::find
+            return Todo.findAll();
+          })
+          .then(function (todos) {
+            assert.equal(todos.length, 1, 'Got one todo');
+            assert.deepEqual(todos[0].attr(), expectedLatest,
+              'findAll returned with updated Todo');
+            // ::get
+            return Todo.findOne({ id: todos[0].id });
+          })
+          .then(function (todo) {
+            assert.deepEqual(todo.attr(), expectedLatest, 'findOne returned');
+            // ::remove
+            return todo.destroy();
+          })
+          .then(function () {
+            return Todo.findAll();
+          })
+          .then(function () {
+            return Task.findAll();
+          })
+          .then(function (todos) {
+            assert.equal(todos.length, 0, 'Deleted todo');
+            assert.equal(sock.id, newSocket.id, 'New socket ids match.');
+            assert.notEqual(socket.id, sock.id, 'Not using old socket.');
+
+            assert.equal(todos.length, 0, 'Deleted todo');
+            done();
           });
         });
       });
+
     });
 
     it('passes service errors', function (done) {


### PR DESCRIPTION
This PR makes it so that Models can be created before or after can.Feathers.connect().  I also put in a check at line 56 to only create a new Model.ready internal deferred if the current one isn't still pending.  I've also update the tests with a Task model created after can.Feathers is already connected.