### PR TITLE
General cleanup & bug fixes.

### DIFF
--- a/lib/feathers.js
+++ b/lib/feathers.js
@@ -10,16 +10,18 @@
   }
 }(this, function (can, Model, Map, feathersClient) {
 
+  var sock = null;
+  var masterDef = new can.Deferred();
+
   var connection = new Map({
-    // The socket is set up here to respond to changes.
-    socket:{}
+    ready:false,
   });
 
   var SocketModel = Model.extend({
     // Here we store locks that prevent dispatching
     // created, updated and removed events multiple times
     _locks: {},
-    ready: new can.Deferred(),
+    ready: can.Deferred(),
 
     setup: function () {
       var self = this;
@@ -30,29 +32,29 @@
         return false;
       }
 
-      this.makeClient();
+      // Make sure there's a socket in place before making the internal client.
+      masterDef.then(function(){
+        self.makeClient();
+
+        // If the socket changes, update the internal Feathers client.
+        connection.bind('ready', function(ev, ready){
+          if (ready) {
+            self.makeClient();
+          }
+        });
+      });
 
       this.create = function (attrs, params) {
         return this.send('create', null, attrs, params || {});
       };
 
       this.update = function (id, attrs, params) {
-        this._locks[id] = 'update';
         return this.send('update', id, attrs, params || {});
       };
 
       this.destroy = function (id, attrs, params) {
-        this._locks[id] = 'remove';
         return this.send('remove', id, params || {});
       };
-
-      // If the socket changes, update the internal Feathers client.
-      connection.bind('socket', function(ev, socket){
-        if (socket) {
-          self.ready = new can.Deferred();
-          self.makeClient();
-        }
-      });
     },
 
     // Processes request for create, update, and destroy
@@ -63,7 +65,7 @@
         name = args.shift();
 
       // Name doesn't use id.
-      if (name == 'create') {
+      if (name === 'create') {
         args.splice(0, 1);
       }
 
@@ -90,34 +92,34 @@
       return function(params, success, error){
         // A can.Deferred to send back.
         var def = can.Deferred();
-        // The method to be used for converting to models.
-        var method = 'models';
+
         // Add params to args.
         var args = [params || {}];
-
+        // The method to be used for converting to models.
+        var method = 'models';
+        // Add the id for get requests, change method.
+        if (name === 'get') {
+          args.unshift(params.id);
+          method = 'model';
+        }
         // Add the callback to args.
         args[1] = function(err, data){
           if (err) {
             return def.reject(err);
           }
+          // Resolve with converted model data.
           def.resolve(self[method](data));
         };
-        // Add the id for get requests.
-        if (name === 'get') {
-          args.unshift(params.id);
-          method = 'model';
-        }
         // Hook up success and error handlers
         def.then(success, error);
 
+        // When the internal client is in place, send the request.
         self.ready.then(function(){
-          // Send the request.
           self.client[name].apply(self.client, args);
         });
         return def;
       };
     },
-
 
     // Uses this.makeFind() to create the Model's findAll().
     makeFindAll: function(){
@@ -130,28 +132,14 @@
     },
 
     makeClient: function(){
-      var socket = connection.attr('socket');
+      this.client = feathersClient(this.resource, sock);
 
       var events = ['create', 'update', 'remove'];
 
-      // If we already have event handlers, turn them off.
-      if (this.hasHandlers) {
-        for (var i = 0; i < events.length; i++) {
-          this.client.off(events[i] + 'd', this.makeHandler(events[i]));
-        }
+      for (var n = 0; n < events.length; n++) {
+        this.client.on(events[n] + 'd', this.makeHandler(events[n]));
       }
-
-      // Create the Feathers client for this model.
-      this.client = feathersClient(this.resource, socket);
-
-      // Setup new event handlers.
-      for (var i = 0; i < events.length; i++) {
-        this.client.on(events[i] + 'd', this.makeHandler(events[i]));
-      }
-
       this.ready.resolve();
-
-      this.hasHandlers = true;
     },
 
     // Creates a resource event handler function for a given event
@@ -212,21 +200,22 @@
 
       // Sets up all current and future models to use the provided socket.
       function useSocket(socket){
-        // Disconnect the old socket.
-        var old = connection.attr('socket');
-        if (old && old.disconnect) {
-          connection.attr('socket').disconnect();
-        }
-        // Remove the old socket.
-        connection.removeAttr('socket');
 
-        // Set up the new socket.
-        connection.attr('socket', socket);
+        // Disconnect the old socket.
+        if (sock && sock.disconnect) {
+          sock.disconnect();
+        }
+
+        // Swap sockets
+        connection.attr('ready', false);
+        sock = socket;
+        connection.attr('ready', true);
 
         self.socketID = socket.id;
 
         def.resolve(socket);
-      };
+        masterDef.resolve();
+      }
 
       // If the socket is connected...
       if(socket.connected){
@@ -241,7 +230,7 @@
         }
       } else {
         // Otherwise, wait for a connect event to fire.
-        socket.on('connect', function() {
+        socket.once('connect', function() {
           useSocket(socket);
         });
       }
@@ -250,8 +239,8 @@
     },
 
     disconnect:function(){
-      if (connection.attr('socket')) {
-        connection.attr('socket').disconnect();
+      if (sock) {
+        sock.disconnect();
       }
     }
   };

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Todo.findAll().then(function(todos) {
 ```
 
 ## Changing Sockets
-As of version 3.0, it is possible to switch sockets after connecting.  This is valuable for apps that need real-time communication both before and after authentication.  Here is an example of switching sockets:
+As of version 2.1, it is possible to switch sockets after connecting.  This is valuable for apps that need real-time communication both before and after authentication.  Here is an example of switching sockets:
 
 ```js
 // Connect without authentication...

--- a/readme.md
+++ b/readme.md
@@ -100,12 +100,13 @@ Todo.findAll({}) // Gets public todos and potentially private todos,
 **Please note that `{forceNew:true}` is required when reconnecting.**
 
 
-## Author
+## Authors
 
 - [David Luecke](https://github.com/daffl)
+- [Marshall Thompson](https://github.com/marshallswain)
 
 ## License
 
-Copyright (c) 2014 David Luecke
+Copyright (c) 2015 David Luecke
 
 Licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
This is what the last merge should have looked like.  It is passing automated tests and now handles server disconnects, reconnects, and socket swaps gracefully.

This fixes a few bugs; one that would cause event handlers to stop working if disconnected from the server.  It was caused by using `socket.on('connect, fn)` instead of `socket.once('connect', fn)`.  Additional overhead caused by that oversight was removed.

`connection.bind('ready')` has been moved inside the `masterDef.then()` to prevent duplicate handlers from being created upon `can.Feathers.connect()`.

Other general cleanup includes removing the `socket.off()` calls.  They aren't necessary when using `socket.disconnect()`.  The duplicate locks inside `this.create()`, `this.update()`, and `this.delete()` were also removed.  A few lines of code were rearranged to follow the logical flow of setting up arguments.